### PR TITLE
only notify cd server if webhook secret is set

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'temurin'
+          distribution: "temurin"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build
@@ -87,15 +87,28 @@ jobs:
     name: "Notify CD server"
     runs-on: ubuntu-latest
     needs: [upload]
+    env:
+      WEBHOOK_SECRET: ${{ secrets.GITOPS_WEBHOOK_SECRET }}
     steps:
+      - name: Check if Secret is set
+        id: secret-check
+        run: |
+          if [ -z "${WEBHOOK_SECRET}" ]; then
+            echo "GITOPS_WEBHOOK_SECRET is not set. Skipping notify step."
+            echo "secret_set=false" >> $GITHUB_OUTPUT
+          else
+            echo "GITOPS_WEBHOOK_SECRET is set. Proceeding with notify step."
+            echo "secret_set=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install Curl
+        if: ${{ steps.secret-check.outputs.secret_set == 'true' }}
         run: sudo apt-get install -y curl
       - name: Trigger GitOps deploy webhook
-        env:
-          WEBHOOK_SECRET: ${{ secrets.GITOPS_WEBHOOK_SECRET }}
+        if: ${{ steps.secret-check.outputs.secret_set == 'true' }}
         run: |
           SIGNATURE=$(printf '{"action":"published"}' | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | cut -d ' ' -f2)
-          
+
           # Send POST request to webhook
           curl -X POST https://gitops.say.software/redeploy-and-update/gitops-deploy-server \
             -H "X-Hub-Signature-256: sha256=$SIGNATURE" \


### PR DESCRIPTION
Prevents failing actions/unauthed pings to your server from forks.
(You might also want to think about moving `https://gitops.say.software/redeploy-and-update/gitops-deploy-server`  into an environment variable.)